### PR TITLE
Implement TTL-based model expiration with persistence and tests

### DIFF
--- a/main.py
+++ b/main.py
@@ -9,7 +9,10 @@ from fastapi import FastAPI
 
 from src.core.config import settings
 from src.db.database import init_db
+import src.db.expiry_policy  # noqa: F401 — register table with SQLAlchemy Base
+import src.db.expiry_audit  # noqa: F401 — register table with SQLAlchemy Base
 from src.routers import router
+from src.services.expiry_service import ExpiryService, ExpiryScheduler
 
 # Configure logging
 logging.basicConfig(
@@ -40,9 +43,19 @@ async def lifespan(app: FastAPI):
     init_db()
     logger.info("Database initialized successfully")
 
+    # Start model expiry scheduler
+    expiry_service = ExpiryService()
+    app.state.expiry_service = expiry_service
+    expiry_scheduler = ExpiryScheduler(expiry_service)
+    expiry_scheduler.start()
+    app.state.expiry_scheduler = expiry_scheduler
+
     yield
 
     logger.info("Shutting down NWDAF ML Service...")
+    expiry_scheduler = getattr(app.state, "expiry_scheduler", None)
+    if expiry_scheduler:
+        expiry_scheduler.stop()
 
 
 # Create FastAPI app

--- a/src/db/expiry_audit.py
+++ b/src/db/expiry_audit.py
@@ -1,0 +1,31 @@
+"""Database model for the model expiry audit log."""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Integer, JSON, String
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.db.database import Base
+
+
+class ExpiryAuditDB(Base):
+    """Immutable audit record written each time a model is expired by the sweep."""
+
+    __tablename__ = "nwdaf_expiry_audit"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    model_id: Mapped[str] = mapped_column(String, nullable=False, index=True)
+    model_name: Mapped[str] = mapped_column(String, nullable=False)
+    expired_at: Mapped[datetime] = mapped_column(
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+    last_used_at: Mapped[datetime | None] = mapped_column(nullable=True)
+    effective_ttl_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    policy_snapshot: Mapped[dict] = mapped_column(JSON, nullable=False)
+
+    def __repr__(self) -> str:
+        return (
+            f"<ExpiryAuditDB(id={self.id}, model_id={self.model_id}, "
+            f"model_name={self.model_name}, expired_at={self.expired_at})>"
+        )

--- a/src/db/expiry_policy.py
+++ b/src/db/expiry_policy.py
@@ -1,0 +1,30 @@
+"""Database model for the model expiry policy."""
+
+from datetime import datetime, timezone
+
+from sqlalchemy import Integer
+from sqlalchemy.orm import Mapped, mapped_column
+
+from src.db.database import Base
+
+
+class ExpiryPolicyDB(Base):
+    """Persisted expiry policy. Append-only: latest row by id wins."""
+
+    __tablename__ = "nwdaf_expiry_policy"
+
+    id: Mapped[int] = mapped_column(primary_key=True, autoincrement=True)
+    base_ttl_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    tolerance_per_use_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    max_tolerance_days: Mapped[int] = mapped_column(Integer, nullable=False)
+    sweep_interval_seconds: Mapped[int] = mapped_column(Integer, nullable=False)
+    updated_at: Mapped[datetime] = mapped_column(
+        nullable=False,
+        default=lambda: datetime.now(timezone.utc),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<ExpiryPolicyDB(id={self.id}, base_ttl_days={self.base_ttl_days}, "
+            f"sweep_interval_seconds={self.sweep_interval_seconds})>"
+        )

--- a/src/routers/v1/__init__.py
+++ b/src/routers/v1/__init__.py
@@ -3,6 +3,7 @@ from .fields_router import router as fields_router
 from .training_router import router as training_router
 from .inference_router import router as inference_router
 from .performance_router import router as performance_router
+from .expiry_router import router as expiry_router
 from fastapi import APIRouter
 
 router = APIRouter()
@@ -11,3 +12,4 @@ router.include_router(fields_router, prefix="/fields")
 router.include_router(training_router, prefix="/training")
 router.include_router(inference_router, prefix="/inference", tags=["Inference"])
 router.include_router(performance_router, prefix="/performance", tags=["Performance"])
+router.include_router(expiry_router, prefix="/expiry", tags=["Expiry"])

--- a/src/routers/v1/__init__.py
+++ b/src/routers/v1/__init__.py
@@ -3,7 +3,6 @@ from .fields_router import router as fields_router
 from .training_router import router as training_router
 from .inference_router import router as inference_router
 from .performance_router import router as performance_router
-<<<<<<< HEAD
 from .expiry_router import router as expiry_router
 from .anomaly_router import router as anomaly_router
 from fastapi import APIRouter

--- a/src/routers/v1/expiry_router.py
+++ b/src/routers/v1/expiry_router.py
@@ -1,0 +1,62 @@
+"""REST endpoints for model expiry policy management and audit log."""
+
+from fastapi import APIRouter, Depends, HTTPException, Request
+from sqlalchemy.orm import Session
+
+from src.db.database import get_db
+from src.db.expiry_audit import ExpiryAuditDB
+from src.schemas.expiry import AuditEntry, ExpiryPolicy, ExpiryPolicyUpdate
+
+router = APIRouter()
+
+
+def _expiry_service(request: Request):
+    svc = getattr(request.app.state, "expiry_service", None)
+    if svc is None:
+        raise HTTPException(status_code=503, detail="Expiry service not available")
+    return svc
+
+
+@router.get("/policy", response_model=ExpiryPolicy)
+def get_policy(request: Request):
+    """Return the current model expiry policy."""
+    return _expiry_service(request).get_policy()
+
+
+@router.patch("/policy", response_model=ExpiryPolicy)
+def patch_policy(update: ExpiryPolicyUpdate, request: Request):
+    """Partially update the expiry policy. Omitted fields keep their current value."""
+    return _expiry_service(request).update_policy(update)
+
+
+@router.put("/policy", response_model=ExpiryPolicy)
+def replace_policy(policy: ExpiryPolicy, request: Request):
+    """Fully replace the expiry policy."""
+    return _expiry_service(request).replace_policy(policy)
+
+
+@router.post("/sweep")
+def trigger_sweep(request: Request):
+    """Manually trigger an expiry sweep and return how many models were deleted."""
+    try:
+        deleted = _expiry_service(request).run_sweep()
+        return {"deleted": deleted}
+    except Exception as e:
+        raise HTTPException(status_code=500, detail=str(e))
+
+
+@router.get("/audit", response_model=list[AuditEntry])
+def get_audit(
+    limit: int = 50,
+    offset: int = 0,
+    db: Session = Depends(get_db),
+):
+    """Return the audit log of expired models, newest first."""
+    rows = (
+        db.query(ExpiryAuditDB)
+        .order_by(ExpiryAuditDB.expired_at.desc())
+        .offset(offset)
+        .limit(limit)
+        .all()
+    )
+    return rows

--- a/src/schemas/expiry.py
+++ b/src/schemas/expiry.py
@@ -1,0 +1,33 @@
+"""Pydantic schemas for expiry policy and audit log."""
+
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class ExpiryPolicy(BaseModel):
+    base_ttl_days: int = Field(default=30, ge=1, description="Days before an untrained model expires")
+    tolerance_per_use_days: int = Field(default=1, ge=0, description="Extra days per recorded inference use")
+    max_tolerance_days: int = Field(default=90, ge=0, description="Cap on tolerance days regardless of use count")
+    sweep_interval_seconds: int = Field(default=3600, ge=60, description="How often the expiry sweep runs")
+
+
+class ExpiryPolicyUpdate(BaseModel):
+    """All fields optional for PATCH semantics."""
+
+    base_ttl_days: Optional[int] = Field(default=None, ge=1)
+    tolerance_per_use_days: Optional[int] = Field(default=None, ge=0)
+    max_tolerance_days: Optional[int] = Field(default=None, ge=0)
+    sweep_interval_seconds: Optional[int] = Field(default=None, ge=60)
+
+
+class AuditEntry(BaseModel):
+    model_id: str
+    model_name: str
+    expired_at: datetime
+    last_used_at: Optional[datetime]
+    effective_ttl_days: int
+    policy_snapshot: dict
+
+    model_config = {"from_attributes": True}

--- a/src/services/expiry_service.py
+++ b/src/services/expiry_service.py
@@ -1,0 +1,231 @@
+"""TTL-based model expiry service with PostgreSQL-backed policy and audit log."""
+
+import logging
+import os
+import threading
+from datetime import datetime, timezone
+from typing import Optional
+
+from mlflow.tracking import MlflowClient
+
+from src.db.database import get_db_context
+from src.db.expiry_audit import ExpiryAuditDB
+from src.db.expiry_policy import ExpiryPolicyDB
+from src.db.model_config import ModelConfigDB
+from src.schemas.expiry import ExpiryPolicy, ExpiryPolicyUpdate
+
+logger = logging.getLogger(__name__)
+
+_DEFAULT_POLICY = ExpiryPolicy(
+    base_ttl_days=int(os.getenv("EXPIRY_BASE_TTL_DAYS", "30")),
+    tolerance_per_use_days=int(os.getenv("EXPIRY_TOLERANCE_PER_USE_DAYS", "1")),
+    max_tolerance_days=int(os.getenv("EXPIRY_MAX_TOLERANCE_DAYS", "90")),
+    sweep_interval_seconds=int(os.getenv("EXPIRY_SWEEP_INTERVAL_SECONDS", "3600")),
+)
+
+
+def _load_policy_from_db() -> Optional[ExpiryPolicy]:
+    """Read the latest policy row from the database. Returns None if no row exists."""
+    try:
+        with get_db_context() as db:
+            row = db.query(ExpiryPolicyDB).order_by(ExpiryPolicyDB.id.desc()).first()
+            if row is None:
+                return None
+            return ExpiryPolicy(
+                base_ttl_days=row.base_ttl_days,
+                tolerance_per_use_days=row.tolerance_per_use_days,
+                max_tolerance_days=row.max_tolerance_days,
+                sweep_interval_seconds=row.sweep_interval_seconds,
+            )
+    except Exception as e:
+        logger.warning(f"Could not load expiry policy from DB: {e}")
+        return None
+
+
+def _save_policy_to_db(policy: ExpiryPolicy) -> None:
+    """Persist a new policy row (append-only; latest id wins on read)."""
+    try:
+        with get_db_context() as db:
+            row = ExpiryPolicyDB(
+                base_ttl_days=policy.base_ttl_days,
+                tolerance_per_use_days=policy.tolerance_per_use_days,
+                max_tolerance_days=policy.max_tolerance_days,
+                sweep_interval_seconds=policy.sweep_interval_seconds,
+                updated_at=datetime.now(timezone.utc),
+            )
+            db.add(row)
+            db.commit()
+    except Exception as e:
+        logger.error(f"Could not save expiry policy to DB: {e}")
+
+
+class ExpiryService:
+    """
+    Manages the lifecycle of registered ML models.
+
+    Models that have not been trained (or created) for longer than their
+    effective TTL are automatically deleted from both MLflow and PostgreSQL.
+
+    Effective TTL per model:
+        base_ttl_days + min(use_count * tolerance_per_use_days, max_tolerance_days)
+
+    Note: use_count is reserved for future inference-tracking integration.
+    Currently 0, so only base_ttl_days applies.
+    """
+
+    def __init__(self) -> None:
+        loaded = _load_policy_from_db()
+        if loaded is None:
+            logger.info("No expiry policy in DB — seeding from env var defaults")
+            self._policy = _DEFAULT_POLICY
+            _save_policy_to_db(self._policy)
+        else:
+            logger.info("Loaded expiry policy from DB")
+            self._policy = loaded
+
+    def get_policy(self) -> ExpiryPolicy:
+        return self._policy
+
+    def update_policy(self, update: ExpiryPolicyUpdate) -> ExpiryPolicy:
+        """Apply a partial update to the current policy and persist it."""
+        current = self._policy
+        self._policy = ExpiryPolicy(
+            base_ttl_days=update.base_ttl_days if update.base_ttl_days is not None else current.base_ttl_days,
+            tolerance_per_use_days=update.tolerance_per_use_days if update.tolerance_per_use_days is not None else current.tolerance_per_use_days,
+            max_tolerance_days=update.max_tolerance_days if update.max_tolerance_days is not None else current.max_tolerance_days,
+            sweep_interval_seconds=update.sweep_interval_seconds if update.sweep_interval_seconds is not None else current.sweep_interval_seconds,
+        )
+        _save_policy_to_db(self._policy)
+        return self._policy
+
+    def replace_policy(self, policy: ExpiryPolicy) -> ExpiryPolicy:
+        """Fully replace the current policy and persist it."""
+        self._policy = policy
+        _save_policy_to_db(self._policy)
+        return self._policy
+
+    def run_sweep(self) -> int:
+        """
+        Scan all registered models and delete those whose effective TTL has expired.
+
+        Uses last_trained_at (from latest MLflow run) or created_at as the baseline.
+        Writes an audit record for every deleted model.
+
+        Returns the number of models deleted.
+        """
+        policy = self._policy
+        now = datetime.now(timezone.utc).timestamp()
+        deleted = 0
+
+        try:
+            client = MlflowClient()
+            with get_db_context() as db:
+                model_configs = db.query(ModelConfigDB).all()
+
+                for db_config in model_configs:
+                    try:
+                        model_id = db_config.model_id
+
+                        # Resolve last-activity timestamp from MLflow
+                        last_activity: Optional[datetime] = None
+                        try:
+                            rm = client.get_registered_model(model_id)
+                            if rm.latest_versions:
+                                latest_mv = rm.latest_versions[0]
+                                if latest_mv.run_id:
+                                    run = client.get_run(latest_mv.run_id)
+                                    if run.info.end_time:
+                                        last_activity = datetime.fromtimestamp(
+                                            run.info.end_time / 1000, tz=timezone.utc
+                                        )
+                        except Exception:
+                            pass
+
+                        if last_activity is None:
+                            created = db_config.created_at
+                            if created.tzinfo is None:
+                                created = created.replace(tzinfo=timezone.utc)
+                            last_activity = created
+
+                        use_count = 0  # Future: set from inference tracking tags
+                        tolerance = min(
+                            use_count * policy.tolerance_per_use_days,
+                            policy.max_tolerance_days,
+                        )
+                        effective_ttl_days = policy.base_ttl_days + tolerance
+                        expires_at = last_activity.timestamp() + effective_ttl_days * 86400
+
+                        if now <= expires_at:
+                            continue
+
+                        logger.info(
+                            f"Expiring model '{db_config.name}' (id={model_id}, "
+                            f"last_activity={last_activity.isoformat()}, "
+                            f"effective_ttl={effective_ttl_days}d)"
+                        )
+
+                        # Delete from MLflow (best-effort)
+                        try:
+                            client.delete_registered_model(model_id)
+                        except Exception as e:
+                            logger.warning(f"Failed to delete MLflow model '{model_id}': {e}")
+
+                        # Write audit record
+                        audit = ExpiryAuditDB(
+                            model_id=model_id,
+                            model_name=db_config.name,
+                            expired_at=datetime.now(timezone.utc),
+                            last_used_at=last_activity,
+                            effective_ttl_days=effective_ttl_days,
+                            policy_snapshot=policy.model_dump(),
+                        )
+                        db.add(audit)
+
+                        # Delete from PostgreSQL
+                        db.delete(db_config)
+                        db.commit()
+                        deleted += 1
+
+                    except Exception as e:
+                        logger.warning(f"Error evaluating model '{db_config.model_id}': {e}")
+                        continue
+
+        except Exception as e:
+            logger.error(f"Expiry sweep failed: {e}", exc_info=True)
+
+        logger.info(f"Expiry sweep complete: {deleted} model(s) deleted")
+        return deleted
+
+
+class ExpiryScheduler:
+    """Background thread that runs ExpiryService.run_sweep() on a fixed interval."""
+
+    def __init__(self, expiry_service: ExpiryService) -> None:
+        self._service = expiry_service
+        self._stop_event = threading.Event()
+        self._thread: Optional[threading.Thread] = None
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._thread = threading.Thread(
+            target=self._run,
+            daemon=True,
+            name="expiry-scheduler-thread",
+        )
+        self._thread.start()
+        logger.info("ExpiryScheduler started")
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=5)
+        logger.info("ExpiryScheduler stopped")
+
+    def _run(self) -> None:
+        while not self._stop_event.is_set():
+            try:
+                self._service.run_sweep()
+            except Exception as e:
+                logger.error(f"Expiry sweep failed: {e}", exc_info=True)
+            interval = self._service.get_policy().sweep_interval_seconds
+            self._stop_event.wait(timeout=interval)

--- a/tests/unit/test_expiry_router.py
+++ b/tests/unit/test_expiry_router.py
@@ -1,0 +1,287 @@
+"""Unit tests for expiry router endpoints."""
+
+from datetime import datetime, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+from fastapi.testclient import TestClient
+
+from src.db.expiry_audit import ExpiryAuditDB
+from src.schemas.expiry import ExpiryPolicy
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def mock_expiry_service():
+    """Mock ExpiryService with a default policy pre-configured."""
+    svc = MagicMock()
+    svc.get_policy.return_value = ExpiryPolicy(
+        base_ttl_days=30,
+        tolerance_per_use_days=1,
+        max_tolerance_days=90,
+        sweep_interval_seconds=3600,
+    )
+    return svc
+
+
+@pytest.fixture
+def client(mock_expiry_service):
+    """TestClient with DB init mocked and expiry service injected into app.state."""
+    with patch("src.db.database.init_db"):
+        from main import app
+        app.state.expiry_service = mock_expiry_service
+        yield TestClient(app)
+
+
+def _make_audit_row(model_id="uuid-1", model_name="old_model"):
+    """Build a mock ExpiryAuditDB row with sensible defaults."""
+    row = MagicMock()
+    row.model_id = model_id
+    row.model_name = model_name
+    row.expired_at = datetime(2024, 1, 1, tzinfo=timezone.utc)
+    row.last_used_at = datetime(2023, 12, 1, tzinfo=timezone.utc)
+    row.effective_ttl_days = 30
+    row.policy_snapshot = {"base_ttl_days": 30}
+    return row
+
+
+# ---------------------------------------------------------------------------
+# Policy endpoints
+# ---------------------------------------------------------------------------
+
+class TestExpiryRouterPolicy:
+    """Tests for GET/PATCH/PUT /v1/expiry/policy."""
+
+    def test_get_policy_returns_current_policy(self, client, mock_expiry_service):
+        """GET /v1/expiry/policy returns the active policy."""
+        response = client.get("/v1/expiry/policy")
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["base_ttl_days"] == 30
+        assert data["tolerance_per_use_days"] == 1
+        assert data["max_tolerance_days"] == 90
+        assert data["sweep_interval_seconds"] == 3600
+        mock_expiry_service.get_policy.assert_called_once()
+
+    def test_patch_policy_applies_partial_update(self, client, mock_expiry_service):
+        """PATCH /v1/expiry/policy calls update_policy with the supplied fields."""
+        updated = ExpiryPolicy(
+            base_ttl_days=7,
+            tolerance_per_use_days=1,
+            max_tolerance_days=90,
+            sweep_interval_seconds=3600,
+        )
+        mock_expiry_service.update_policy.return_value = updated
+
+        response = client.patch("/v1/expiry/policy", json={"base_ttl_days": 7})
+
+        assert response.status_code == 200
+        assert response.json()["base_ttl_days"] == 7
+        mock_expiry_service.update_policy.assert_called_once()
+
+    def test_patch_policy_rejects_base_ttl_below_minimum(self, client):
+        """PATCH /v1/expiry/policy returns 422 when base_ttl_days < 1."""
+        response = client.patch("/v1/expiry/policy", json={"base_ttl_days": 0})
+
+        assert response.status_code == 422
+
+    def test_patch_policy_rejects_sweep_interval_below_minimum(self, client):
+        """PATCH /v1/expiry/policy returns 422 when sweep_interval_seconds < 60."""
+        response = client.patch("/v1/expiry/policy", json={"sweep_interval_seconds": 10})
+
+        assert response.status_code == 422
+
+    def test_patch_policy_empty_body_is_accepted(self, client, mock_expiry_service):
+        """PATCH with an empty body is valid (no-op update)."""
+        mock_expiry_service.update_policy.return_value = mock_expiry_service.get_policy.return_value
+
+        response = client.patch("/v1/expiry/policy", json={})
+
+        assert response.status_code == 200
+
+    def test_put_policy_replaces_all_fields(self, client, mock_expiry_service):
+        """PUT /v1/expiry/policy calls replace_policy with the full body."""
+        new_policy = ExpiryPolicy(
+            base_ttl_days=14,
+            tolerance_per_use_days=2,
+            max_tolerance_days=60,
+            sweep_interval_seconds=7200,
+        )
+        mock_expiry_service.replace_policy.return_value = new_policy
+
+        response = client.put(
+            "/v1/expiry/policy",
+            json={
+                "base_ttl_days": 14,
+                "tolerance_per_use_days": 2,
+                "max_tolerance_days": 60,
+                "sweep_interval_seconds": 7200,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["base_ttl_days"] == 14
+        assert data["sweep_interval_seconds"] == 7200
+        mock_expiry_service.replace_policy.assert_called_once()
+
+    def test_put_policy_rejects_invalid_field_value(self, client):
+        """PUT /v1/expiry/policy returns 422 when a field violates its constraint."""
+        response = client.put("/v1/expiry/policy", json={"base_ttl_days": 0})
+
+        assert response.status_code == 422
+
+    def test_policy_endpoint_returns_503_when_service_unavailable(self, client):
+        """GET /v1/expiry/policy returns 503 when expiry_service is not on app.state."""
+        from main import app
+
+        original = app.state.expiry_service
+        del app.state.expiry_service
+        try:
+            response = client.get("/v1/expiry/policy")
+            assert response.status_code == 503
+        finally:
+            app.state.expiry_service = original
+
+
+# ---------------------------------------------------------------------------
+# Sweep endpoint
+# ---------------------------------------------------------------------------
+
+class TestExpiryRouterSweep:
+    """Tests for POST /v1/expiry/sweep."""
+
+    def test_sweep_returns_deleted_count(self, client, mock_expiry_service):
+        """POST /v1/expiry/sweep returns the number of models the sweep deleted."""
+        mock_expiry_service.run_sweep.return_value = 3
+
+        response = client.post("/v1/expiry/sweep")
+
+        assert response.status_code == 200
+        assert response.json() == {"deleted": 3}
+        mock_expiry_service.run_sweep.assert_called_once()
+
+    def test_sweep_returns_zero_when_nothing_expired(self, client, mock_expiry_service):
+        """POST /v1/expiry/sweep returns 0 when no models are expired."""
+        mock_expiry_service.run_sweep.return_value = 0
+
+        response = client.post("/v1/expiry/sweep")
+
+        assert response.status_code == 200
+        assert response.json()["deleted"] == 0
+
+    def test_sweep_returns_500_on_service_error(self, client, mock_expiry_service):
+        """POST /v1/expiry/sweep returns 500 when the sweep raises an exception."""
+        mock_expiry_service.run_sweep.side_effect = RuntimeError("DB connection lost")
+
+        response = client.post("/v1/expiry/sweep")
+
+        assert response.status_code == 500
+        assert "DB connection lost" in response.json()["detail"]
+
+
+# ---------------------------------------------------------------------------
+# Audit endpoint
+# ---------------------------------------------------------------------------
+
+class TestExpiryRouterAudit:
+    """Tests for GET /v1/expiry/audit."""
+
+    def test_get_audit_returns_empty_list(self, client):
+        """GET /v1/expiry/audit returns [] when no entries exist."""
+        from src.db.database import get_db
+        from main import app
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.order_by.return_value \
+            .offset.return_value.limit.return_value.all.return_value = []
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            response = client.get("/v1/expiry/audit")
+            assert response.status_code == 200
+            assert response.json() == []
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_get_audit_returns_entries(self, client):
+        """GET /v1/expiry/audit returns all audit rows."""
+        from src.db.database import get_db
+        from main import app
+
+        rows = [_make_audit_row("uuid-1", "model_alpha"), _make_audit_row("uuid-2", "model_beta")]
+        mock_db = MagicMock()
+        mock_db.query.return_value.order_by.return_value \
+            .offset.return_value.limit.return_value.all.return_value = rows
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            response = client.get("/v1/expiry/audit")
+            assert response.status_code == 200
+            data = response.json()
+            assert len(data) == 2
+            assert data[0]["model_id"] == "uuid-1"
+            assert data[0]["model_name"] == "model_alpha"
+            assert data[1]["model_id"] == "uuid-2"
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_get_audit_applies_limit_and_offset(self, client):
+        """GET /v1/expiry/audit passes limit and offset query params to the DB query."""
+        from src.db.database import get_db
+        from main import app
+
+        mock_db = MagicMock()
+        chain = mock_db.query.return_value.order_by.return_value
+        chain.offset.return_value.limit.return_value.all.return_value = []
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            client.get("/v1/expiry/audit?limit=10&offset=20")
+            chain.offset.assert_called_once_with(20)
+            chain.offset.return_value.limit.assert_called_once_with(10)
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_get_audit_default_limit_is_50(self, client):
+        """GET /v1/expiry/audit uses limit=50 when not specified."""
+        from src.db.database import get_db
+        from main import app
+
+        mock_db = MagicMock()
+        chain = mock_db.query.return_value.order_by.return_value
+        chain.offset.return_value.limit.return_value.all.return_value = []
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            client.get("/v1/expiry/audit")
+            chain.offset.return_value.limit.assert_called_once_with(50)
+        finally:
+            app.dependency_overrides.clear()
+
+    def test_get_audit_entry_fields(self, client):
+        """GET /v1/expiry/audit response includes all AuditEntry fields."""
+        from src.db.database import get_db
+        from main import app
+
+        rows = [_make_audit_row("uuid-99", "expiry_test_model")]
+        mock_db = MagicMock()
+        mock_db.query.return_value.order_by.return_value \
+            .offset.return_value.limit.return_value.all.return_value = rows
+
+        app.dependency_overrides[get_db] = lambda: mock_db
+        try:
+            response = client.get("/v1/expiry/audit")
+            entry = response.json()[0]
+            assert entry["model_id"] == "uuid-99"
+            assert entry["model_name"] == "expiry_test_model"
+            assert entry["effective_ttl_days"] == 30
+            assert "expired_at" in entry
+            assert "last_used_at" in entry
+            assert "policy_snapshot" in entry
+        finally:
+            app.dependency_overrides.clear()

--- a/tests/unit/test_expiry_service.py
+++ b/tests/unit/test_expiry_service.py
@@ -1,0 +1,301 @@
+"""Unit tests for ExpiryService."""
+
+from contextlib import contextmanager
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.db.expiry_audit import ExpiryAuditDB
+from src.db.model_config import ModelConfigDB
+from src.schemas.expiry import ExpiryPolicy, ExpiryPolicyUpdate
+from src.services.expiry_service import ExpiryService
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_model_config(model_id="uuid-1", name="test_model", created_days_ago=0):
+    """Return a ModelConfigDB mock with created_at offset from now."""
+    cfg = MagicMock(spec=ModelConfigDB)
+    cfg.model_id = model_id
+    cfg.name = name
+    cfg.created_at = datetime.now(timezone.utc) - timedelta(days=created_days_ago)
+    return cfg
+
+
+def _make_mlflow_client(last_run_end_time=None):
+    """Return a MlflowClient mock, optionally with a latest run end time."""
+    client = MagicMock()
+    rm = MagicMock()
+    if last_run_end_time is not None:
+        mv = MagicMock()
+        mv.run_id = "run-123"
+        rm.latest_versions = [mv]
+        run = MagicMock()
+        run.info.end_time = int(last_run_end_time.timestamp() * 1000)
+        client.get_run.return_value = run
+    else:
+        rm.latest_versions = []
+    client.get_registered_model.return_value = rm
+    return client
+
+
+def _mock_db_context(mock_db):
+    """Return a get_db_context patch that yields mock_db."""
+    @contextmanager
+    def _ctx():
+        yield mock_db
+    return _ctx
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+def expiry_service():
+    """ExpiryService with no policy in DB → seeds from env defaults."""
+    with patch("src.services.expiry_service._load_policy_from_db", return_value=None), \
+         patch("src.services.expiry_service._save_policy_to_db"):
+        return ExpiryService()
+
+
+# ---------------------------------------------------------------------------
+# Policy management
+# ---------------------------------------------------------------------------
+
+class TestExpiryServicePolicy:
+    """Tests for get_policy / update_policy / replace_policy."""
+
+    def test_get_policy_returns_defaults_when_no_db_entry(self):
+        """Service seeds from env defaults when no policy row exists in DB."""
+        with patch("src.services.expiry_service._load_policy_from_db", return_value=None), \
+             patch("src.services.expiry_service._save_policy_to_db"):
+            svc = ExpiryService()
+
+        policy = svc.get_policy()
+        assert policy.base_ttl_days == 30
+        assert policy.tolerance_per_use_days == 1
+        assert policy.max_tolerance_days == 90
+        assert policy.sweep_interval_seconds == 3600
+
+    def test_get_policy_loads_from_db_when_row_exists(self):
+        """Service uses persisted policy when a DB row is found."""
+        stored = ExpiryPolicy(
+            base_ttl_days=7,
+            tolerance_per_use_days=2,
+            max_tolerance_days=30,
+            sweep_interval_seconds=120,
+        )
+        with patch("src.services.expiry_service._load_policy_from_db", return_value=stored), \
+             patch("src.services.expiry_service._save_policy_to_db"):
+            svc = ExpiryService()
+
+        policy = svc.get_policy()
+        assert policy.base_ttl_days == 7
+        assert policy.sweep_interval_seconds == 120
+
+    def test_seeds_default_policy_to_db_when_no_row(self):
+        """Default policy is persisted to DB on first startup."""
+        with patch("src.services.expiry_service._load_policy_from_db", return_value=None), \
+             patch("src.services.expiry_service._save_policy_to_db") as mock_save:
+            ExpiryService()
+
+        mock_save.assert_called_once()
+
+    def test_update_policy_changes_specified_field_only(self, expiry_service):
+        """PATCH: only the supplied field changes; others are preserved."""
+        with patch("src.services.expiry_service._save_policy_to_db"):
+            result = expiry_service.update_policy(ExpiryPolicyUpdate(base_ttl_days=5))
+
+        assert result.base_ttl_days == 5
+        assert result.tolerance_per_use_days == 1    # unchanged
+        assert result.max_tolerance_days == 90       # unchanged
+        assert result.sweep_interval_seconds == 3600  # unchanged
+
+    def test_update_policy_persists_to_db(self, expiry_service):
+        """PATCH: updated policy is saved to the database."""
+        with patch("src.services.expiry_service._save_policy_to_db") as mock_save:
+            expiry_service.update_policy(ExpiryPolicyUpdate(base_ttl_days=10))
+
+        mock_save.assert_called_once()
+
+    def test_update_policy_reflects_in_get_policy(self, expiry_service):
+        """PATCH: subsequent get_policy returns the updated value."""
+        with patch("src.services.expiry_service._save_policy_to_db"):
+            expiry_service.update_policy(ExpiryPolicyUpdate(base_ttl_days=5))
+
+        assert expiry_service.get_policy().base_ttl_days == 5
+
+    def test_replace_policy_sets_all_fields(self, expiry_service):
+        """PUT: all fields are replaced with the supplied policy."""
+        new_policy = ExpiryPolicy(
+            base_ttl_days=14,
+            tolerance_per_use_days=3,
+            max_tolerance_days=60,
+            sweep_interval_seconds=7200,
+        )
+        with patch("src.services.expiry_service._save_policy_to_db"):
+            result = expiry_service.replace_policy(new_policy)
+
+        assert result.base_ttl_days == 14
+        assert result.tolerance_per_use_days == 3
+        assert result.max_tolerance_days == 60
+        assert result.sweep_interval_seconds == 7200
+
+    def test_replace_policy_persists_to_db(self, expiry_service):
+        """PUT: replaced policy is saved to the database."""
+        new_policy = ExpiryPolicy(
+            base_ttl_days=14,
+            tolerance_per_use_days=3,
+            max_tolerance_days=60,
+            sweep_interval_seconds=7200,
+        )
+        with patch("src.services.expiry_service._save_policy_to_db") as mock_save:
+            expiry_service.replace_policy(new_policy)
+
+        mock_save.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Sweep logic
+# ---------------------------------------------------------------------------
+
+class TestExpiryServiceSweep:
+    """Tests for run_sweep()."""
+
+    def test_sweep_no_models_returns_zero(self, expiry_service):
+        """Sweep with no model configs deletes nothing and returns 0."""
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = []
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient"):
+            result = expiry_service.run_sweep()
+
+        assert result == 0
+
+    def test_sweep_fresh_model_not_deleted(self, expiry_service):
+        """Model created today is not expired under the default TTL of 30 days."""
+        cfg = _make_model_config(created_days_ago=1)
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [cfg]
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=_make_mlflow_client()):
+            result = expiry_service.run_sweep()
+
+        assert result == 0
+        mock_db.delete.assert_not_called()
+
+    def test_sweep_expired_model_deleted(self, expiry_service):
+        """Model created 31 days ago is expired and removed under TTL=30."""
+        cfg = _make_model_config(created_days_ago=31)
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [cfg]
+        mlflow_client = _make_mlflow_client()
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=mlflow_client):
+            result = expiry_service.run_sweep()
+
+        assert result == 1
+        mlflow_client.delete_registered_model.assert_called_once_with(cfg.model_id)
+        mock_db.delete.assert_called_once_with(cfg)
+        mock_db.commit.assert_called_once()
+
+    def test_sweep_writes_audit_record_for_deleted_model(self, expiry_service):
+        """An ExpiryAuditDB row is written for every expired model."""
+        cfg = _make_model_config(created_days_ago=31)
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [cfg]
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=_make_mlflow_client()):
+            expiry_service.run_sweep()
+
+        mock_db.add.assert_called_once()
+        audit_arg = mock_db.add.call_args[0][0]
+        assert isinstance(audit_arg, ExpiryAuditDB)
+        assert audit_arg.model_id == cfg.model_id
+        assert audit_arg.model_name == cfg.name
+
+    def test_sweep_uses_last_run_time_over_created_at(self, expiry_service):
+        """last_activity comes from the latest MLflow run, not created_at."""
+        # created 60 days ago but trained 1 day ago → should NOT expire with TTL=30
+        cfg = _make_model_config(created_days_ago=60)
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [cfg]
+
+        recent = datetime.now(timezone.utc) - timedelta(days=1)
+        mlflow_client = _make_mlflow_client(last_run_end_time=recent)
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=mlflow_client):
+            result = expiry_service.run_sweep()
+
+        assert result == 0
+        mlflow_client.delete_registered_model.assert_not_called()
+
+    def test_sweep_falls_back_to_created_at_when_no_run(self, expiry_service):
+        """When no MLflow run exists, created_at is used as last_activity."""
+        # No run, created 31 days ago → expires with TTL=30
+        cfg = _make_model_config(created_days_ago=31)
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [cfg]
+
+        # MlflowClient returns a model with no versions
+        mlflow_client = _make_mlflow_client(last_run_end_time=None)
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=mlflow_client):
+            result = expiry_service.run_sweep()
+
+        assert result == 1
+
+    def test_sweep_handles_mlflow_delete_failure(self, expiry_service):
+        """MLflow delete failure does not abort the sweep; DB record is still removed."""
+        cfg = _make_model_config(created_days_ago=31)
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [cfg]
+
+        mlflow_client = _make_mlflow_client()
+        mlflow_client.delete_registered_model.side_effect = Exception("MLflow unavailable")
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=mlflow_client):
+            result = expiry_service.run_sweep()
+
+        assert result == 1
+        mock_db.delete.assert_called_once_with(cfg)
+
+    def test_sweep_counts_only_expired_models(self, expiry_service):
+        """Sweep returns the count of actually expired models, not total models."""
+        expired1 = _make_model_config("id-1", "old_1", created_days_ago=35)
+        expired2 = _make_model_config("id-2", "old_2", created_days_ago=40)
+        fresh = _make_model_config("id-3", "fresh", created_days_ago=5)
+
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [expired1, expired2, fresh]
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=_make_mlflow_client()):
+            result = expiry_service.run_sweep()
+
+        assert result == 2
+
+    def test_sweep_audit_record_contains_policy_snapshot(self, expiry_service):
+        """Audit record captures a snapshot of the policy at sweep time."""
+        cfg = _make_model_config(created_days_ago=31)
+        mock_db = MagicMock()
+        mock_db.query.return_value.all.return_value = [cfg]
+
+        with patch("src.services.expiry_service.get_db_context", _mock_db_context(mock_db)), \
+             patch("src.services.expiry_service.MlflowClient", return_value=_make_mlflow_client()):
+            expiry_service.run_sweep()
+
+        audit_arg = mock_db.add.call_args[0][0]
+        assert "base_ttl_days" in audit_arg.policy_snapshot
+        assert audit_arg.policy_snapshot["base_ttl_days"] == 30


### PR DESCRIPTION
Correction  of the TTL expire persistance. Before the models that were deleted got totally erased, now they are audited