### PR TITLE
add dockerfile for postgres

### DIFF
--- a/Dockerfile.postgres
+++ b/Dockerfile.postgres
@@ -1,0 +1,3 @@
+FROM postgres:15
+COPY sql/init-db.sh /docker-entrypoint-initdb.d/init-db.sh
+RUN chmod +x /docker-entrypoint-initdb.d/init-db.sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,14 +20,15 @@ services:
         condition: service_healthy
 
   postgres:
-    image: postgres:15
+    build:
+      context: .
+      dockerfile: Dockerfile.postgres
     container_name: mlflow-postgres
     environment:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
     volumes:
       - pgdata:/var/lib/postgresql/data
-      - ./sql/init-db.sh:/docker-entrypoint-initdb.d/init-db.sh
     networks:
       - nwdaf-ml
     ports:


### PR DESCRIPTION
## Summary
This pr adds a Dockerfile for postgres allowing the use of docker context to deploy postgres on another machine

## Explanation
When using docker context to place container on another machine, the mount is placed as a empty directory