### PR TITLE
Update anomaly detection logic to use all models

### DIFF
--- a/src/routers/v1/anomaly_router.py
+++ b/src/routers/v1/anomaly_router.py
@@ -394,14 +394,15 @@ async def run_all_anomaly_detection(
             result = await detection_service.detect(
                 request.cell_id, model_cfg.model_id, request.lookback_seconds
             )
-            models_meta[result.model_name] = AnomalyModelMeta(
+            models_meta[result.model_id] = AnomalyModelMeta(
+                name=result.model_name,
                 fields=result.input_fields,
                 threshold=result.threshold_value,
                 window_duration_seconds=result.window_duration_seconds,
             )
             for ip_result in result.results:
                 ip = ip_result.ip_src
-                ip_anomalies.setdefault(ip, {})[result.model_name] = (
+                ip_anomalies.setdefault(ip, {})[result.model_id] = (
                     f"{ip_result.num_anomalies}/{ip_result.num_windows}"
                 )
         except Exception as e:

--- a/src/schemas/anomaly.py
+++ b/src/schemas/anomaly.py
@@ -173,6 +173,7 @@ class AnomalyDetectionResult(BaseModel):
 class AnomalyModelMeta(BaseModel):
     """Metadata for a model used in a summary."""
 
+    name: str
     fields: list[str]
     threshold: float
     window_duration_seconds: int

--- a/src/services/inference_pipeline.py
+++ b/src/services/inference_pipeline.py
@@ -72,14 +72,15 @@ class InferencePipeline:
                     anomaly = await self.anomaly_detection_service.detect(
                         cell_id, model_id=model_cfg.model_id
                     )
-                    models_meta[anomaly.model_name] = AnomalyModelMeta(
+                    models_meta[anomaly.model_id] = AnomalyModelMeta(
+                        name=anomaly.model_name,
                         fields=anomaly.input_fields,
                         threshold=anomaly.threshold_value,
                         window_duration_seconds=anomaly.window_duration_seconds,
                     )
                     for ip_result in anomaly.results:
                         ip = ip_result.ip_src
-                        ip_anomalies.setdefault(ip, {})[anomaly.model_name] = (
+                        ip_anomalies.setdefault(ip, {})[anomaly.model_id] = (
                             f"{ip_result.num_anomalies}/{ip_result.num_windows}"
                         )
                 except Exception as e:


### PR DESCRIPTION
## Summary

This pr changes the logic when doing anomaly detection for a cell. Now all compatible models are applied over the target cell. This matters because each anomaly detection model can be trained to detect a specific anomaly ( irregular syn values, etc)