### PR TITLE
Add encryption support when fetching cells from data-storage

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,8 @@ TRAIN_KUBE_TOKEN=<ServiceAccount token>
 TRAIN_KUBE_CA_CERT=<base64-encoded PEM certificate>
 TRAIN_KUBE_NAMESPACE=default
 TRAIN_KUBE_IMAGE=cnt00/pei-ml-train-worker:latest
+
+# Encryption (DH key exchange + AES-256-GCM)
+# Set to true to perform a handshake with data-storage and decrypt responses
+# Works both with and without Kubernetes — ENCRYPTION_ENABLED is forwarded to K8s job pods automatically
+ENCRYPTION_ENABLED=false

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -43,6 +43,7 @@ services:
       - TRAIN_KUBE_CA_CERT=${TRAIN_KUBE_CA_CERT}
       - TRAIN_KUBE_NAMESPACE=${TRAIN_KUBE_NAMESPACE}
       - TRAIN_KUBE_IMAGE=${TRAIN_KUBE_IMAGE}
+      - ENCRYPTION_ENABLED=${ENCRYPTION_ENABLED:-false}
     networks:
       - nwdaf-ml
       - nwdaf-network

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,6 +20,7 @@ dependencies = [
     "kubernetes>=35.0.0",
     "alibi>=0.9.0",
     "shap>=0.41.0,<=0.44.1",
+    "pei-nwdaf-encryptor @ git+https://github.com/ATNoG/pei-nwdaf-encryptor.git",
 ]
 
 [project.optional-dependencies]
@@ -41,6 +42,9 @@ url = "https://download.pytorch.org/whl/cpu"
 
 [tool.hatch.build.targets.wheel]
 packages = ["src"]
+
+[tool.hatch.metadata]
+allow-direct-references = true
 
 [build-system]
 requires = ["hatchling"]

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -54,5 +54,8 @@ class Settings(BaseSettings):
     TRAIN_KUBE_NAMESPACE: str = "default"
     TRAIN_KUBE_IMAGE: str = ""
 
+    # Encryption (DH key exchange + AES-256-GCM)
+    ENCRYPTION_ENABLED: bool = False
+
 
 settings = Settings()

--- a/src/services/data_storage_client.py
+++ b/src/services/data_storage_client.py
@@ -1,8 +1,13 @@
 """Client for interacting with the Data Storage API."""
 
+import json
+import logging
+
 import httpx
 
 from src.core.config import settings
+
+logger = logging.getLogger(__name__)
 
 
 class DataStorageClient:
@@ -16,6 +21,45 @@ class DataStorageClient:
         self.excluded_fields = set(
             f.strip() for f in settings.DATA_STORAGE_EXCLUDED_FIELDS.split(",") if f.strip()
         )
+        self._encryptor_client = None
+        self._handshake_done = False
+        self._session_token: str | None = None
+        if settings.ENCRYPTION_ENABLED:
+            from encryptor.core.secure_channel_client import EncryptorClient
+            self._encryptor_client = EncryptorClient()
+
+    def _ensure_handshake(self) -> None:
+        """Perform the DH handshake with data-storage if not yet done."""
+        if self._encryptor_client is None or self._handshake_done:
+            return
+        try:
+            self._encryptor_client.handshake(self.base_url)
+            self._handshake_done = True
+            self._session_token = self._encryptor_client.session_token
+            logger.info(
+                "Encryption handshake with data-storage completed (session=%s).",
+                self._session_token,
+            )
+        except Exception as exc:
+            logger.warning("Encryption handshake failed, continuing without encryption: %s", exc)
+            self._encryptor_client = None
+
+    @property
+    def _auth_headers(self) -> dict[str, str]:
+        """Headers to attach to every data-storage request."""
+        if self._session_token:
+            return {"X-Session-Token": self._session_token}
+        return {}
+
+    def _decrypt_response(self, response: httpx.Response) -> bytes:
+        """Decrypt the response body if the server marked it as encrypted."""
+        if (
+            self._encryptor_client is not None
+            and self._handshake_done
+            and response.headers.get("X-Encrypted") == "true"
+        ):
+            return self._encryptor_client.decrypt(response.content)
+        return response.content
 
     async def get_available_fields(self) -> list[str]:
         """
@@ -24,13 +68,15 @@ class DataStorageClient:
         Returns a list of field names, excluding metadata fields defined in
         DATA_STORAGE_EXCLUDED_FIELDS.
         """
+        self._ensure_handshake()
         url = f"{self.base_url}{self.example_endpoint}"
 
         async with httpx.AsyncClient() as client:
-            response = await client.get(url, timeout=10.0)
+            response = await client.get(url, timeout=10.0, headers=self._auth_headers)
             response.raise_for_status()
 
-            data = response.json()
+            raw = self._decrypt_response(response)
+            data = json.loads(raw)
 
             # data is a list with at least one example record
             if not data or not isinstance(data, list):
@@ -71,12 +117,13 @@ class DataStorageClient:
         Returns:
             List of cell indexes (integers)
         """
+        self._ensure_handshake()
         url = f"{self.base_url}{self.cell_endpoint}"
 
         async with httpx.AsyncClient() as client:
-            response = await client.get(url, timeout=30.0)
+            response = await client.get(url, timeout=30.0, headers=self._auth_headers)
             response.raise_for_status()
-            return response.json()
+            return json.loads(self._decrypt_response(response))
 
     async def probe_data_timestamp(
         self, cells: list[int], window_duration_seconds: int
@@ -92,6 +139,7 @@ class DataStorageClient:
         import time
         from datetime import datetime, timezone
 
+        self._ensure_handshake()
         far_future = int(time.time()) + 10 * 365 * 24 * 3600
         url = f"{self.base_url}{self.data_endpoint}"
 
@@ -106,9 +154,11 @@ class DataStorageClient:
                         "offset": 0,
                         "limit": 1,
                     }
-                    response = await client.get(url, params=params, timeout=30.0)
+                    response = await client.get(
+                        url, params=params, timeout=30.0, headers=self._auth_headers
+                    )
                     if response.status_code == 200:
-                        data = response.json()
+                        data = json.loads(self._decrypt_response(response))
                         if data and isinstance(data, list):
                             raw = data[0].get("window_start_time", 0)
                             if isinstance(raw, str):
@@ -145,6 +195,7 @@ class DataStorageClient:
         Returns:
             List of data windows with metrics (all pages combined)
         """
+        self._ensure_handshake()
         url = f"{self.base_url}{self.data_endpoint}"
         all_data = []
         offset = 0
@@ -163,9 +214,11 @@ class DataStorageClient:
                 if ip_src is not None:
                     params["ip_src"] = ip_src
 
-                response = await client.get(url, params=params, timeout=60.0)
+                response = await client.get(
+                    url, params=params, timeout=60.0, headers=self._auth_headers
+                )
                 response.raise_for_status()
-                batch = response.json()
+                batch = json.loads(self._decrypt_response(response))
 
                 if not batch:
                     # No more data

--- a/src/services/kube_training.py
+++ b/src/services/kube_training.py
@@ -40,6 +40,7 @@ class KubeTrainingService:
                 "DATA_STORAGE_CELL_ENDPOINT": settings.DATA_STORAGE_CELL_ENDPOINT,
                 "DATA_STORAGE_EXCLUDED_FIELDS": settings.DATA_STORAGE_EXCLUDED_FIELDS,
                 "LOG_LEVEL": settings.LOG_LEVEL,
+                "ENCRYPTION_ENABLED": str(settings.ENCRYPTION_ENABLED).lower(),
             },
             resources=resources or self._DEFAULT_RESOURCES,
         )

--- a/tests/unit/test_data_storage_client.py
+++ b/tests/unit/test_data_storage_client.py
@@ -16,6 +16,7 @@ def mock_settings():
         mock.DATA_STORAGE_EXCLUDED_FIELDS = "window_start_time,window_end_time,window_duration_seconds,cell_index,network,sample_count"
         mock.DATA_STORAGE_DATA_ENDPOINT = "/api/v1/processed/latency"
         mock.DATA_STORAGE_CELL_ENDPOINT = "/api/v1/cell"
+        mock.ENCRYPTION_ENABLED = False
         yield mock
 
 
@@ -62,12 +63,14 @@ class TestDataStorageClient:
     @pytest.mark.asyncio
     async def test_get_available_fields_success(self, mock_settings, sample_example_response):
         """Test successfully fetching available fields."""
+        import json as _json
         client = DataStorageClient()
 
         # Mock httpx response
         with patch("httpx.AsyncClient") as mock_async_client:
             mock_response = MagicMock()
-            mock_response.json.return_value = sample_example_response
+            mock_response.content = _json.dumps(sample_example_response).encode()
+            mock_response.headers = {}
             mock_response.raise_for_status = MagicMock()
 
             mock_client_instance = AsyncMock()
@@ -81,6 +84,7 @@ class TestDataStorageClient:
             mock_client_instance.get.assert_called_once_with(
                 "http://data-storage:8000/api/v1/processed/latency/example",
                 timeout=10.0,
+                headers={},
             )
 
             # Verify excluded fields are removed
@@ -104,11 +108,13 @@ class TestDataStorageClient:
     @pytest.mark.asyncio
     async def test_get_available_fields_empty_response(self, mock_settings):
         """Test handling empty response."""
+        import json as _json
         client = DataStorageClient()
 
         with patch("httpx.AsyncClient") as mock_async_client:
             mock_response = MagicMock()
-            mock_response.json.return_value = []
+            mock_response.content = _json.dumps([]).encode()
+            mock_response.headers = {}
             mock_response.raise_for_status = MagicMock()
 
             mock_client_instance = AsyncMock()
@@ -162,6 +168,7 @@ class TestDataStorageClient:
             mock.DATA_STORAGE_API_URL = "http://data-storage:8000"
             mock.DATA_STORAGE_EXAMPLE_ENDPOINT = "/api/v1/processed/latency/example"
             mock.DATA_STORAGE_EXCLUDED_FIELDS = " field1 , field2 ,  field3  "
+            mock.ENCRYPTION_ENABLED = False
 
             client = DataStorageClient()
 
@@ -174,6 +181,7 @@ class TestDataStorageClient:
             mock.DATA_STORAGE_API_URL = "http://data-storage:8000"
             mock.DATA_STORAGE_EXAMPLE_ENDPOINT = "/api/v1/processed/latency/example"
             mock.DATA_STORAGE_EXCLUDED_FIELDS = ""
+            mock.ENCRYPTION_ENABLED = False
 
             client = DataStorageClient()
 
@@ -182,11 +190,13 @@ class TestDataStorageClient:
     @pytest.mark.asyncio
     async def test_validate_fields_all_valid(self, mock_settings, sample_example_response):
         """Test validating fields when all are valid."""
+        import json as _json
         client = DataStorageClient()
 
         with patch("httpx.AsyncClient") as mock_async_client:
             mock_response = MagicMock()
-            mock_response.json.return_value = sample_example_response
+            mock_response.content = _json.dumps(sample_example_response).encode()
+            mock_response.headers = {}
             mock_response.raise_for_status = MagicMock()
 
             mock_client_instance = AsyncMock()
@@ -202,11 +212,13 @@ class TestDataStorageClient:
     @pytest.mark.asyncio
     async def test_validate_fields_some_invalid(self, mock_settings, sample_example_response):
         """Test validating fields when some are invalid."""
+        import json as _json
         client = DataStorageClient()
 
         with patch("httpx.AsyncClient") as mock_async_client:
             mock_response = MagicMock()
-            mock_response.json.return_value = sample_example_response
+            mock_response.content = _json.dumps(sample_example_response).encode()
+            mock_response.headers = {}
             mock_response.raise_for_status = MagicMock()
 
             mock_client_instance = AsyncMock()
@@ -224,11 +236,13 @@ class TestDataStorageClient:
     @pytest.mark.asyncio
     async def test_validate_fields_all_invalid(self, mock_settings, sample_example_response):
         """Test validating fields when all are invalid."""
+        import json as _json
         client = DataStorageClient()
 
         with patch("httpx.AsyncClient") as mock_async_client:
             mock_response = MagicMock()
-            mock_response.json.return_value = sample_example_response
+            mock_response.content = _json.dumps(sample_example_response).encode()
+            mock_response.headers = {}
             mock_response.raise_for_status = MagicMock()
 
             mock_client_instance = AsyncMock()
@@ -244,12 +258,14 @@ class TestDataStorageClient:
     @pytest.mark.asyncio
     async def test_get_known_cells_success(self, mock_settings):
         """Test successfully fetching known cells."""
+        import json as _json
         client = DataStorageClient()
         mock_cells = [0, 1, 2, 5, 7]
 
         with patch("httpx.AsyncClient") as mock_async_client:
             mock_response = MagicMock()
-            mock_response.json.return_value = mock_cells
+            mock_response.content = _json.dumps(mock_cells).encode()
+            mock_response.headers = {}
             mock_response.raise_for_status = MagicMock()
 
             mock_client_instance = AsyncMock()
@@ -264,6 +280,7 @@ class TestDataStorageClient:
     @pytest.mark.asyncio
     async def test_fetch_cell_data_success(self, mock_settings):
         """Test successfully fetching cell data."""
+        import json as _json
         client = DataStorageClient()
         mock_data = [
             {
@@ -277,7 +294,8 @@ class TestDataStorageClient:
 
         with patch("httpx.AsyncClient") as mock_async_client:
             mock_response = MagicMock()
-            mock_response.json.return_value = mock_data
+            mock_response.content = _json.dumps(mock_data).encode()
+            mock_response.headers = {}
             mock_response.raise_for_status = MagicMock()
 
             mock_client_instance = AsyncMock()


### PR DESCRIPTION
# Add Encryption Support for Data Storage Communication
## Summary
- Integrates end-to-end encryption between the ML service and the Data Storage service using a Diffie-Hellman key exchange followed by AES-256-GCM symmetric encryption, provided by the shared [pei-nwdaf-encryptor](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) library.

Changes
src/services/data_storage_client.py — Extended DataStorageClient with:

- Lazy DH handshake with the Data Storage service (_ensure_handshake)
- Session token attachment via X-Session-Token header on every request
- Response decryption when the server signals X-Encrypted: true
- Graceful fallback: if the handshake fails, the client continues operating without encryption
- src/core/config.py — Added ENCRYPTION_ENABLED: bool setting (defaults to false)

- src/services/kube_training.py — Forwards ENCRYPTION_ENABLED to Kubernetes training job pods so workers inherit the same encryption configuration

- pyproject.toml — Added [pei-nwdaf-encryptor](vscode-file://vscode-app/opt/visual-studio-code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) as a direct Git dependency and enabled