### PR TITLE
Security/isolation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -98,20 +98,20 @@ services:
     tmpfs:
       - /tmp
       - /root/.cache
-    deploy:
-      resources:
-        limits:
-          memory: 2G
-          cpus: '2'
     networks:
       - nwdaf-ml
-      - nwdaf-network
     restart: unless-stopped
     depends_on:
       mlflow:
         condition: service_healthy
     healthcheck:
-      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8061/health')"]
+      test:
+        [
+          "CMD",
+          "python",
+          "-c",
+          "import urllib.request; urllib.request.urlopen('http://localhost:8061/health')",
+        ]
       interval: 10s
       timeout: 5s
       retries: 5
@@ -152,7 +152,13 @@ services:
     networks:
       - nwdaf-ml
     healthcheck:
-      test: ["CMD", "curl", "-f", "http://localhost:${MINIO_PORT}/minio/health/live"]
+      test:
+        [
+          "CMD",
+          "curl",
+          "-f",
+          "http://localhost:${MINIO_PORT}/minio/health/live",
+        ]
       interval: 5s
       timeout: 3s
       retries: 20

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,7 @@ services:
     build:
       context: .
       dockerfile: docker/Dockerfile.main
+    image: pei-ml-service:latest
     ports:
       - "8060:8060"
     environment:
@@ -57,6 +58,7 @@ services:
       - DEV_MODE=${DEV_MODE:-false}
       - KEYCLOAK_URL=${KEYCLOAK_URL:-http://keycloak:8080/auth}
       - KEYCLOAK_REALM=${KEYCLOAK_REALM:-aion}
+      - INFERENCE_WORKER_URL=http://inference-worker:8061
     networks:
       - nwdaf-ml
       - nwdaf-network
@@ -64,6 +66,52 @@ services:
     depends_on:
       mlflow:
         condition: service_healthy
+      inference-worker:
+        condition: service_healthy
+
+  inference-worker:
+    image: pei-ml-service:latest
+    container_name: pei-inference-worker
+    command: ["/app/.venv/bin/python", "-m", "src.workers.inference_worker"]
+    environment:
+      - LOG_LEVEL=${LOG_LEVEL}
+      - MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}
+      - MLFLOW_S3_ENDPOINT_URL=${MLFLOW_S3_ENDPOINT_URL}
+      - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
+      - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD}
+      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
+      - DATA_STORAGE_API_URL=${DATA_STORAGE_API_URL}
+      - DATA_STORAGE_EXAMPLE_ENDPOINT=${DATA_STORAGE_EXAMPLE_ENDPOINT}
+      - DATA_STORAGE_DATA_ENDPOINT=${DATA_STORAGE_DATA_ENDPOINT}
+      - DATA_STORAGE_CELL_ENDPOINT=${DATA_STORAGE_CELL_ENDPOINT}
+      - DATA_STORAGE_EXCLUDED_FIELDS=${DATA_STORAGE_EXCLUDED_FIELDS}
+      - DATABASE_URL=${DATABASE_URL}
+      - INFERENCE_WORKER_URL=http://localhost:8061
+    cap_drop:
+      - ALL
+    security_opt:
+      - no-new-privileges:true
+    read_only: true
+    tmpfs:
+      - /tmp
+      - /root/.cache
+    deploy:
+      resources:
+        limits:
+          memory: 2G
+          cpus: '2'
+    networks:
+      - nwdaf-ml
+      - nwdaf-network
+    restart: unless-stopped
+    depends_on:
+      mlflow:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD", "python", "-c", "import urllib.request; urllib.request.urlopen('http://localhost:8061/health')"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
 
   postgres:
     build:

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -58,6 +58,9 @@ class Settings(BaseSettings):
     TRAIN_MAX_EPOCHS: int = 100
     ADD_TEST_MODELS: bool = False
 
+    # Inference worker
+    INFERENCE_WORKER_URL: str = "http://inference-worker:8061"
+
     # Kubernetes training
     TRAIN_USE_KUBE: bool = False
     TRAIN_KUBE_HOST: str = ""

--- a/src/services/inference_service.py
+++ b/src/services/inference_service.py
@@ -4,11 +4,13 @@ import asyncio
 import logging
 from datetime import datetime, timezone
 
+import httpx
 import mlflow
 import numpy as np
 
 from src.core.config import settings
 from src.services.model_loader import load_trained_model
+from src.services.safe_predict import safe_predict, sync_safe_predict
 from src.schemas.inference import ForecastStepPrediction
 from src.schemas.model import ModelConfig
 from src.schemas.performance import LocalExplanationResponse
@@ -139,14 +141,7 @@ class InferenceService:
                 f"Train the model first via POST /v1/training/train"
             )
 
-        # Load trained model from MLflow - sync call, run in thread
-        model = await asyncio.to_thread(
-            self._load_trained_model,
-            model_id=model_id,
-            version=model_detail.latest_version,
-            config=config,
-        )
-
+        model_uri = f"models:/{model_id}/{model_detail.latest_version}"
         lookback_seconds = config.lookback_steps * config.window_duration_seconds
         start_ts, end_ts = calculate_timestamps(lookback_seconds + config.window_duration_seconds)
 
@@ -175,11 +170,7 @@ class InferenceService:
 
         X = np.nan_to_num(X, nan=0.0)
 
-        # Run prediction
-        try:
-            raw_predictions = model.predict(X)
-        except Exception as e:
-            raise RuntimeError(f"Prediction failed: {str(e)}")
+        raw_predictions = await safe_predict(config.architecture, model_uri, config, X)
 
         asyncio.create_task(_dlt_trace_inference(
             model_run_id=model_detail.mlflow_run_id or "",
@@ -236,7 +227,7 @@ class InferenceService:
         if explain:
             try:
                 explanation = await self._explain_kernelshap(
-                    model=model,
+                    model_uri=model_uri,
                     config=config,
                     model_id=model_id,
                     version=model_detail.latest_version,
@@ -282,13 +273,7 @@ class InferenceService:
         if model_detail.latest_version is None:
             raise ValueError(f"Model '{model_id}' has no trained versions.")
 
-        model = await asyncio.to_thread(
-            self._load_trained_model,
-            model_id=model_id,
-            version=model_detail.latest_version,
-            config=config,
-        )
-
+        model_uri = f"models:/{model_id}/{model_detail.latest_version}"
         lookback_seconds = config.lookback_steps * config.window_duration_seconds
         start_ts, end_ts = calculate_timestamps(lookback_seconds + config.window_duration_seconds)
 
@@ -314,10 +299,7 @@ class InferenceService:
         )
         X = np.nan_to_num(X, nan=0.0)
 
-        try:
-            raw_predictions = model.predict(X)
-        except Exception as e:
-            raise RuntimeError(f"Prediction failed: {e}")
+        raw_predictions = await safe_predict(config.architecture, model_uri, config, X)
 
         def _ts(window, field):
             ts = window.get(field, 0)
@@ -398,7 +380,7 @@ class InferenceService:
 
     async def _explain_kernelshap(
         self,
-        model,
+        model_uri: str,
         config: ModelConfig,
         model_id: str,
         version: int,
@@ -427,7 +409,7 @@ class InferenceService:
 
         def predict_fn(X_2d: np.ndarray) -> np.ndarray:
             X_3d = bridge.reconstruct(X_2d)
-            preds = model.predict(X_3d)
+            preds = sync_safe_predict(config.architecture, model_uri, config, X_3d)
             return preds[:, field_idx::num_out].mean(axis=1)
 
         x_instance_2d = np.array([[0.0] * n_fields])       # index 0 = target
@@ -444,7 +426,7 @@ class InferenceService:
             name: round(float(v), 6)
             for name, v in zip(config.input_fields, shap_values)
         }
-        pred_for_field = model.predict(X_instance)[0][field_idx::num_out].tolist()
+        pred_for_field = sync_safe_predict(config.architecture, model_uri, config, X_instance)[0][field_idx::num_out].tolist()
 
         logger.info(
             "KernelSHAP tags=%s field='%s' baseline=%.4f attributions=%s",

--- a/src/services/performance_service.py
+++ b/src/services/performance_service.py
@@ -24,6 +24,7 @@ from src.services.data_preparation import calculate_timestamps, prepare_last_seq
 from src.services.data_storage_client import DataStorageClient
 from src.services.mlflow_service import MLflowService
 from src.services.model_loader import load_trained_model
+from src.services.safe_predict import sync_safe_predict
 
 logger = logging.getLogger(__name__)
 
@@ -191,9 +192,9 @@ class PerformanceService:
 
             detail_map[model_config.model_id] = model_detail
             try:
-                model = self._load_model(model_config.model_id, model_detail.latest_version, config)
-                loaded_models[model_config.model_id] = model
-                score = await self._compute_score_for_model(model, config, field_name, event_type, metric, fallback_start_ts)
+                _model_uri = f"models:/{model_config.model_id}/{model_detail.latest_version}"
+                loaded_models[model_config.model_id] = _model_uri
+                score = await self._compute_score_for_model(_model_uri, config, field_name, event_type, metric, fallback_start_ts)
             except Exception as e:
                 logger.warning(
                     f"Failed to evaluate model {model_config.model_id} for field '{field_name}': {e}"
@@ -229,7 +230,7 @@ class PerformanceService:
         if best_model_id and best_model_id in loaded_models:
             try:
                 importances = await self._compute_permutation_importance(
-                    model=loaded_models[best_model_id],
+                    model_uri=loaded_models[best_model_id],
                     config=detail_map[best_model_id].config,
                     field_name=field_name,
                     event_type=event_type,
@@ -433,8 +434,8 @@ class PerformanceService:
             config.window_duration_seconds, event_type=model_event_type or None
         )
 
-        model = self._load_model(best.model_id, model_detail.latest_version, config)
-        score = await self._compute_score_for_model(model, config, field_name, model_event_type, metric, fallback_start_ts)
+        _model_uri = f"models:/{best.model_id}/{model_detail.latest_version}"
+        score = await self._compute_score_for_model(_model_uri, config, field_name, model_event_type, metric, fallback_start_ts)
 
         evaluated_at = datetime.now(tz=timezone.utc)
         evaluated_at_str = evaluated_at.isoformat()
@@ -562,7 +563,7 @@ class PerformanceService:
 
     async def _compute_score_for_model(
         self,
-        model,
+        model_uri: str,
         config: ModelConfig,
         field_name: str,
         event_type: str,
@@ -620,7 +621,7 @@ class PerformanceService:
             X = prepare_last_sequence(x_windows, config.input_fields, config.lookback_steps)
 
             try:
-                pred = model.predict(X)[0]
+                pred = sync_safe_predict(config.architecture, model_uri, config, X)[0]
             except Exception as e:
                 logger.warning("Prediction failed for slice %s: %s", slice_key, e)
                 continue
@@ -660,7 +661,7 @@ class PerformanceService:
 
     async def _compute_permutation_importance(
         self,
-        model,
+        model_uri: str,
         config: ModelConfig,
         field_name: str,
         event_type: str,
@@ -721,7 +722,7 @@ class PerformanceService:
             if len(X) == 0:
                 return np.zeros((0,), dtype=np.float32)
             X_3d = bridge.reconstruct(X)
-            preds = model.predict(X_3d)
+            preds = sync_safe_predict(config.architecture, model_uri, config, X_3d)
             return preds[:, field_idx::num_out].mean(axis=1)
 
         scorer = _make_alibi_scorer(metric, self._compute_score)
@@ -782,7 +783,7 @@ class PerformanceService:
         if model_detail.latest_version is None:
             raise ValueError(f"Model '{model_id}' has no trained version")
         config = model_detail.config
-        model = self._load_model(model_id, model_detail.latest_version, config)
+        _model_uri = f"models:/{model_id}/{model_detail.latest_version}"
         event_type = getattr(model_detail, "event_type", "")
         fallback_start_ts = await self.data_storage_client.probe_data_timestamp(
             config.window_duration_seconds, event_type=event_type or None
@@ -791,7 +792,7 @@ class PerformanceService:
 
         metric = tags.get(_metric_key(field_name), "rmse")
         importances = await self._compute_permutation_importance(
-            model=model,
+            model_uri=_model_uri,
             config=config,
             field_name=field_name,
             event_type=event_type,

--- a/src/services/safe_predict.py
+++ b/src/services/safe_predict.py
@@ -1,0 +1,56 @@
+import logging
+
+import httpx
+import numpy as np
+
+from src.core.config import settings
+
+logger = logging.getLogger(__name__)
+
+
+def _payload(architecture: str, model_uri: str, config, X: np.ndarray) -> dict:
+    return {
+        "architecture": architecture,
+        "model_uri": model_uri,
+        "config": config.model_dump(),
+        "X": X.tolist(),
+    }
+
+
+def sync_safe_predict(architecture: str, model_uri: str, config, X: np.ndarray) -> np.ndarray:
+    """Sync version — use inside sync callbacks (e.g. KernelSHAP predict_fn)."""
+    with httpx.Client(timeout=60.0) as client:
+        try:
+            r = client.post(
+                f"{settings.INFERENCE_WORKER_URL}/predict",
+                json=_payload(architecture, model_uri, config, X),
+            )
+            r.raise_for_status()
+            return np.array(r.json()["output"], dtype=np.float32)
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as e:
+            logger.error("Inference worker unreachable: %s", e)
+            raise RuntimeError("Inference service unavailable. Try again later.")
+        except httpx.HTTPStatusError as e:
+            raise RuntimeError(f"Prediction failed: {e.response.json().get('detail', str(e))}")
+
+
+async def safe_predict(architecture: str, model_uri: str, config, X: np.ndarray) -> np.ndarray:
+    """Send prediction request to isolated inference worker container.
+
+    Worker loads and caches the model by model_uri. All dangerous operations
+    (exec, torch.load, predict) run in a container with cap_drop=[ALL].
+    """
+    async with httpx.AsyncClient(timeout=60.0) as client:
+        try:
+            r = await client.post(
+                f"{settings.INFERENCE_WORKER_URL}/predict",
+                json=_payload(architecture, model_uri, config, X),
+            )
+            r.raise_for_status()
+            return np.array(r.json()["output"], dtype=np.float32)
+        except (httpx.ConnectError, httpx.TimeoutException, httpx.NetworkError) as e:
+            logger.error("Inference worker unreachable: %s", e)
+            raise RuntimeError("Inference service unavailable. Try again later.")
+        except httpx.HTTPStatusError as e:
+            detail = e.response.json().get("detail", str(e))
+            raise RuntimeError(f"Prediction failed: {detail}")

--- a/src/workers/inference_worker.py
+++ b/src/workers/inference_worker.py
@@ -1,0 +1,90 @@
+"""Isolated inference worker — exec + torch.load + predict with cap_drop=[ALL]."""
+
+import asyncio
+import logging
+import os
+
+import mlflow
+import numpy as np
+import uvicorn
+from fastapi import FastAPI, HTTPException
+from pydantic import BaseModel
+
+from src.core.config import settings
+from src.schemas.model import ModelConfig
+from src.services.model_loader import load_trained_model
+
+logging.basicConfig(
+    level=settings.LOG_LEVEL,
+    format="%(asctime)s %(name)-20s %(levelname)-8s %(message)s",
+)
+logger = logging.getLogger(__name__)
+
+app = FastAPI(title="Inference Worker", docs_url=None, redoc_url=None)
+
+_model_cache: dict[str, object] = {}
+_MAX_CACHE = 20
+
+
+class PredictRequest(BaseModel):
+    architecture: str
+    model_uri: str
+    config: dict
+    X: list
+
+
+class PredictResponse(BaseModel):
+    output: list
+
+
+@app.on_event("startup")
+async def startup():
+    mlflow.set_tracking_uri(settings.MLFLOW_TRACKING_URI)
+    os.environ["MLFLOW_S3_ENDPOINT_URL"] = settings.MLFLOW_S3_ENDPOINT_URL
+    os.environ["AWS_ACCESS_KEY_ID"] = settings.AWS_ACCESS_KEY_ID
+    os.environ["AWS_SECRET_ACCESS_KEY"] = settings.AWS_SECRET_ACCESS_KEY
+    os.environ["AWS_DEFAULT_REGION"] = settings.AWS_DEFAULT_REGION
+    logger.info("Inference worker ready")
+
+
+@app.post("/predict", response_model=PredictResponse)
+async def predict(req: PredictRequest):
+    try:
+        config = ModelConfig(**req.config)
+    except Exception as e:
+        raise HTTPException(status_code=422, detail=f"Invalid config: {e}")
+
+    if req.model_uri not in _model_cache:
+        if len(_model_cache) >= _MAX_CACHE:
+            oldest = next(iter(_model_cache))
+            del _model_cache[oldest]
+        try:
+            model = await asyncio.to_thread(
+                load_trained_model, req.architecture, req.model_uri, config
+            )
+            _model_cache[req.model_uri] = model
+            logger.info("Cached model %s", req.model_uri)
+        except Exception as e:
+            logger.error("Failed to load %s: %s", req.model_uri, e)
+            raise HTTPException(status_code=500, detail=f"Model load failed: {e}")
+
+    model = _model_cache[req.model_uri]
+
+    try:
+        X = np.array(req.X, dtype=np.float32)
+        X = np.nan_to_num(X, nan=0.0)
+        raw = await asyncio.to_thread(model.predict, X)
+        return PredictResponse(output=raw.tolist())
+    except Exception as e:
+        _model_cache.pop(req.model_uri, None)
+        logger.error("Prediction failed for %s: %s", req.model_uri, e)
+        raise HTTPException(status_code=500, detail=f"Prediction failed: {e}")
+
+
+@app.get("/health")
+def health():
+    return {"status": "ok"}
+
+
+if __name__ == "__main__":
+    uvicorn.run(app, host="0.0.0.0", port=8061)

--- a/tests/unit/test_inference_service.py
+++ b/tests/unit/test_inference_service.py
@@ -103,15 +103,9 @@ class TestInferenceServicePredict:
             return_value=sample_cell_data
         )
 
-        # Mock model loading and prediction
-        mock_model = MagicMock()
-        mock_model.predict.return_value = np.zeros(
-            (1, forecast_steps * num_outputs), dtype=np.float32
-        )
-
         with patch(
-            "src.services.inference_service.load_trained_model",
-            return_value=mock_model,
+            "src.services.inference_service.safe_predict",
+            return_value=np.zeros((1, forecast_steps * num_outputs), dtype=np.float32),
         ):
             result = await inference_service.predict(
                 output_field="latency_mean",
@@ -160,14 +154,10 @@ class TestInferenceServicePredict:
         mock_mlflow_service.get_model.return_value = sample_model_detail
         mock_data_storage_client.fetch_data = AsyncMock(return_value=[])
 
-        mock_model = MagicMock()
-        with patch("src.services.inference_service.load_trained_model") as mock_registry:
-            mock_registry.return_value = mock_model
-
-            with pytest.raises(ValueError, match="No data for tags"):
-                await inference_service.predict(
-                    output_field="latency_mean", tags={"snssai_sst": "1", "dnn": "internet", "event": "PERF_DATA"}, model_id="test-uuid"
-                )
+        with pytest.raises(ValueError, match="No data for tags"):
+            await inference_service.predict(
+                output_field="latency_mean", tags={"snssai_sst": "1", "dnn": "internet", "event": "PERF_DATA"}, model_id="test-uuid"
+            )
 
     async def test_predict_insufficient_data(
         self,
@@ -187,14 +177,10 @@ class TestInferenceServicePredict:
             return_value=sparse_data
         )
 
-        mock_model = MagicMock()
-        with patch("src.services.inference_service.load_trained_model") as mock_registry:
-            mock_registry.return_value = mock_model
-
-            with pytest.raises(ValueError, match="Insufficient data"):
-                await inference_service.predict(
-                    output_field="latency_mean", tags={"snssai_sst": "1", "dnn": "internet", "event": "PERF_DATA"}, model_id="test-uuid"
-                )
+        with pytest.raises(ValueError, match="Insufficient data"):
+            await inference_service.predict(
+                output_field="latency_mean", tags={"snssai_sst": "1", "dnn": "internet", "event": "PERF_DATA"}, model_id="test-uuid"
+            )
 
     async def test_predict_model_failure(
         self,
@@ -210,12 +196,10 @@ class TestInferenceServicePredict:
             return_value=sample_cell_data
         )
 
-        mock_model = MagicMock()
-        mock_model.predict.side_effect = RuntimeError("CUDA error")
-
-        with patch("src.services.inference_service.load_trained_model") as mock_registry:
-            mock_registry.return_value = mock_model
-
+        with patch(
+            "src.services.inference_service.safe_predict",
+            side_effect=RuntimeError("Prediction failed: CUDA error"),
+        ):
             with pytest.raises(RuntimeError, match="Prediction failed"):
                 await inference_service.predict(
                     output_field="latency_mean", tags={"snssai_sst": "1", "dnn": "internet", "event": "PERF_DATA"}, model_id="test-uuid"
@@ -236,22 +220,13 @@ class TestInferenceServicePredict:
             return_value=sample_cell_data
         )
 
-        mock_model = MagicMock()
-        mock_model.predict.return_value = np.zeros(
-            (1, config.forecast_steps * len(config.output_fields)),
-            dtype=np.float32,
-        )
-
         with patch(
-            "mlflow.pytorch.load_model"
+            "src.services.inference_service.safe_predict",
+            return_value=np.zeros((1, config.forecast_steps * len(config.output_fields)), dtype=np.float32),
         ), patch(
-            "src.services.inference_service.load_trained_model"
-        ) as mock_registry, patch(
             "src.services.inference_service.calculate_timestamps",
             return_value=(1000, 2000),
         ) as mock_ts:
-            mock_registry.return_value = mock_model
-
             await inference_service.predict(
                 output_field="latency_mean", tags={"snssai_sst": "1", "dnn": "internet", "event": "PERF_DATA"}, model_id="test-uuid"
             )

--- a/uv.lock
+++ b/uv.lock
@@ -2095,8 +2095,8 @@ dependencies = [
     { name = "psycopg2-binary" },
     { name = "pydantic" },
     { name = "pydantic-settings" },
-    { name = "python-multipart" },
     { name = "pyjwt", extra = ["crypto"] },
+    { name = "python-multipart" },
     { name = "ray" },
     { name = "scikit-learn" },
     { name = "shap" },
@@ -2123,7 +2123,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.9.0" },
-    { name = "alibi", specifier = ">=0.9.4" },
+    { name = "alibi", specifier = "==0.9.4" },
     { name = "boto3", specifier = ">=1.35.0" },
     { name = "cachetools", specifier = ">=5.3.0" },
     { name = "confluent-kafka", specifier = ">=2.13.2" },


### PR DESCRIPTION
## Summary
Add a isolated container to run inferences.

## Explanation
This helps on security since we now support custom architectures with code that may be insecure.

This new container:
- is limited to ml network ( with a override it can be made internal to block any access to external ips)
- is read-only
- uses the same image as mlservice but with a different entrypoint