### PR TITLE
Inference isolation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -70,6 +70,7 @@ services:
     networks:
       - nwdaf-ml
       - nwdaf-network
+      - inference_network
     restart: unless-stopped
     depends_on:
       mlflow:
@@ -96,18 +97,6 @@ services:
       ]
     environment:
       - LOG_LEVEL=${LOG_LEVEL}
-      - MLFLOW_TRACKING_URI=${MLFLOW_TRACKING_URI}
-      - MLFLOW_S3_ENDPOINT_URL=${MLFLOW_S3_ENDPOINT_URL}
-      - AWS_ACCESS_KEY_ID=${MINIO_ROOT_USER}
-      - AWS_SECRET_ACCESS_KEY=${MINIO_ROOT_PASSWORD}
-      - AWS_DEFAULT_REGION=${AWS_DEFAULT_REGION:-us-east-1}
-      - DATA_STORAGE_API_URL=${DATA_STORAGE_API_URL}
-      - DATA_STORAGE_EXAMPLE_ENDPOINT=${DATA_STORAGE_EXAMPLE_ENDPOINT}
-      - DATA_STORAGE_DATA_ENDPOINT=${DATA_STORAGE_DATA_ENDPOINT}
-      - DATA_STORAGE_CELL_ENDPOINT=${DATA_STORAGE_CELL_ENDPOINT}
-      - DATA_STORAGE_EXCLUDED_FIELDS=${DATA_STORAGE_EXCLUDED_FIELDS}
-      - DATABASE_URL=${DATABASE_URL}
-      - INFERENCE_WORKER_URL=http://localhost:8061
     cap_drop:
       - ALL
     security_opt:
@@ -117,11 +106,8 @@ services:
       - /tmp
       - /root/.cache
     networks:
-      - nwdaf-ml
+      - inference_network
     restart: unless-stopped
-    depends_on:
-      mlflow:
-        condition: service_healthy
     healthcheck:
       test:
         [
@@ -258,3 +244,6 @@ networks:
     driver: bridge
   nwdaf-network:
     name: nwdaf-network
+  inference_network:
+    driver: bridge
+    internal: true

--- a/src/core/config.py
+++ b/src/core/config.py
@@ -13,25 +13,25 @@ class Settings(BaseSettings):
     # API Configuration
     API_HOST: str = "0.0.0.0"
     API_PORT: int = 8060
-    LOG_LEVEL: str
+    LOG_LEVEL: str = "INFO"
 
     # MLflow Configuration
-    MLFLOW_TRACKING_URI: str
-    MLFLOW_S3_ENDPOINT_URL: str
-    AWS_ACCESS_KEY_ID: str
-    AWS_SECRET_ACCESS_KEY: str
+    MLFLOW_TRACKING_URI: str = ""
+    MLFLOW_S3_ENDPOINT_URL: str = ""
+    AWS_ACCESS_KEY_ID: str = ""
+    AWS_SECRET_ACCESS_KEY: str = ""
     AWS_DEFAULT_REGION: str = "us-east-1"
 
     # Data Storage API
-    DATA_STORAGE_API_URL: str
-    DATA_STORAGE_EXAMPLE_ENDPOINT: str
-    DATA_STORAGE_EXCLUDED_FIELDS: str
-    DATA_STORAGE_DATA_ENDPOINT: str
-    DATA_STORAGE_CELL_ENDPOINT: str
+    DATA_STORAGE_API_URL: str = ""
+    DATA_STORAGE_EXAMPLE_ENDPOINT: str = ""
+    DATA_STORAGE_EXCLUDED_FIELDS: str = ""
+    DATA_STORAGE_DATA_ENDPOINT: str = ""
+    DATA_STORAGE_CELL_ENDPOINT: str = ""
     DATA_STORAGE_FIELDS_ENDPOINT: str = "/api/v1/processed/fields"
 
     # Database Configuration
-    DATABASE_URL: str
+    DATABASE_URL: str = ""
 
     # Auto-monitoring
     MONITORING_ENABLED: bool = True

--- a/src/services/architecture_service.py
+++ b/src/services/architecture_service.py
@@ -30,6 +30,10 @@ class ArchitectureService:
 
         self._ensure_bucket()
 
+    def get_raw_bytes(self, architecture_id: str) -> bytes:
+        response = self.s3.get_object(Bucket=_BUCKET_NAME, Key=architecture_id)
+        return response["Body"].read()
+
     @contextmanager
     def load_architecture(self, architecture_id: str):
         cls, content = self._load(architecture_id)
@@ -37,6 +41,26 @@ class ArchitectureService:
             yield cls, content
         finally:
             self._unload(architecture_id)
+
+    @contextmanager
+    def load_from_bytes(self, architecture_id: str, content: bytes):
+        module_name = self.module_name(architecture_id)
+        namespace = self._make_namespace(module_name)
+        exec(content, namespace)  # nosec B102
+        mod = types.ModuleType(module_name)
+        mod.__dict__.update(namespace)
+        sys.modules[module_name] = mod
+        cls = next(
+            (v for v in namespace.values()
+             if isinstance(v, type) and issubclass(v, ModelInterface) and v is not ModelInterface),
+            None,
+        )
+        if cls is None:
+            raise ValueError(f"No ModelInterface subclass found in bytes for {architecture_id}")
+        try:
+            yield cls, content
+        finally:
+            sys.modules.pop(module_name, None)
 
     def _load(self, architecture_id: str) -> tuple[type, bytes]:
         response = self.s3.get_object(Bucket=_BUCKET_NAME, Key=architecture_id)

--- a/src/services/safe_predict.py
+++ b/src/services/safe_predict.py
@@ -1,5 +1,7 @@
 import base64
 import logging
+import os
+import tempfile
 
 import httpx
 import numpy as np
@@ -10,6 +12,10 @@ logger = logging.getLogger(__name__)
 
 _async_client: httpx.AsyncClient | None = None
 _sync_client: httpx.Client | None = None
+
+# Cache: model_uri -> (arch_bytes, model_bytes)
+_bytes_cache: dict[str, tuple[bytes, bytes]] = {}
+_MAX_BYTES_CACHE = 20
 
 
 def _get_async_client() -> httpx.AsyncClient:
@@ -32,11 +38,43 @@ def _get_sync_client() -> httpx.Client:
     return _sync_client
 
 
-def _payload(architecture: str, model_uri: str, config, X: np.ndarray) -> dict:
+def _fetch_artifact_bytes(model_uri: str) -> bytes:
+    """Download model artifact bytes from MLflow/MinIO without torch.load."""
+    import mlflow
+    with tempfile.TemporaryDirectory() as tmpdir:
+        local_path = mlflow.artifacts.download_artifacts(
+            artifact_uri=model_uri,
+            dst_path=tmpdir,
+        )
+        for root, _, files in os.walk(local_path):
+            for f in files:
+                if f.endswith(".pth"):
+                    with open(os.path.join(root, f), "rb") as fp:
+                        return fp.read()
+    raise ValueError(f"No .pth file found in artifact {model_uri}")
+
+
+def _get_bytes(architecture_id: str, model_uri: str) -> tuple[bytes, bytes]:
+    global _bytes_cache
+    if model_uri not in _bytes_cache:
+        if len(_bytes_cache) >= _MAX_BYTES_CACHE:
+            oldest = next(iter(_bytes_cache))
+            del _bytes_cache[oldest]
+        from src.services.architecture_service import ArchitectureService
+        arch_bytes = ArchitectureService().get_raw_bytes(architecture_id)
+        model_bytes = _fetch_artifact_bytes(model_uri)
+        _bytes_cache[model_uri] = (arch_bytes, model_bytes)
+        logger.info("Cached bytes for %s", model_uri)
+    return _bytes_cache[model_uri]
+
+
+def _payload(architecture_id: str, model_uri: str, config, X: np.ndarray) -> dict:
+    arch_bytes, model_bytes = _get_bytes(architecture_id, model_uri)
     arr = np.ascontiguousarray(X, dtype=np.float32)
     return {
-        "architecture": architecture,
-        "model_uri": model_uri,
+        "architecture_id": architecture_id,
+        "arch_bytes": base64.b64encode(arch_bytes).decode(),
+        "model_bytes": base64.b64encode(model_bytes).decode(),
         "config": config.model_dump(),
         "X_bytes": base64.b64encode(arr.tobytes()).decode(),
         "X_shape": list(arr.shape),
@@ -62,10 +100,10 @@ def sync_safe_predict(architecture: str, model_uri: str, config, X: np.ndarray) 
 
 
 async def safe_predict(architecture: str, model_uri: str, config, X: np.ndarray) -> np.ndarray:
-    """Send prediction request to isolated inference worker container.
+    """Send prediction request to isolated inference worker.
 
-    Worker loads and caches the model by model_uri. All dangerous operations
-    (exec, torch.load, predict) run in a container with cap_drop=[ALL].
+    MLservice downloads arch + model bytes, caches them, sends to worker.
+    Worker has no MLflow/MinIO access — exec + torch.load run in cap_drop=[ALL] sandbox.
     """
     client = _get_async_client()
     try:

--- a/src/workers/inference_worker.py
+++ b/src/workers/inference_worker.py
@@ -1,35 +1,36 @@
-"""Isolated inference worker — exec + torch.load + predict with cap_drop=[ALL]."""
+"""Isolated inference worker — exec + torch.load + predict with cap_drop=[ALL].
+
+Receives arch_bytes + model_bytes from mlservice (no MinIO/MLflow access needed).
+"""
 
 import asyncio
 import base64
 import logging
-import os
 
-import mlflow
 import numpy as np
 import uvicorn
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel
 
-from src.core.config import settings
 from src.schemas.model import ModelConfig
-from src.services.model_loader import load_trained_model
+from src.services.architecture_service import ArchitectureService
+
+# Pre-built ArchitectureService instance with no MinIO connection (only _make_namespace + load_from_bytes needed)
+_arch_svc = ArchitectureService.__new__(ArchitectureService)
 
 logging.basicConfig(
-    level=settings.LOG_LEVEL,
+    level="INFO",
     format="%(asctime)s %(name)-20s %(levelname)-8s %(message)s",
 )
 logger = logging.getLogger(__name__)
 
 app = FastAPI(title="Inference Worker", docs_url=None, redoc_url=None)
 
-_model_cache: dict[str, object] = {}
-_MAX_CACHE = 20
-
 
 class PredictRequest(BaseModel):
-    architecture: str
-    model_uri: str
+    architecture_id: str
+    arch_bytes: str    # base64-encoded Python source
+    model_bytes: str   # base64-encoded .pth file
     config: dict
     X_bytes: str
     X_shape: list[int]
@@ -40,14 +41,29 @@ class PredictResponse(BaseModel):
     output_shape: list[int]
 
 
-@app.on_event("startup")
-async def startup():
-    mlflow.set_tracking_uri(settings.MLFLOW_TRACKING_URI)
-    os.environ["MLFLOW_S3_ENDPOINT_URL"] = settings.MLFLOW_S3_ENDPOINT_URL
-    os.environ["AWS_ACCESS_KEY_ID"] = settings.AWS_ACCESS_KEY_ID
-    os.environ["AWS_SECRET_ACCESS_KEY"] = settings.AWS_SECRET_ACCESS_KEY
-    os.environ["AWS_DEFAULT_REGION"] = settings.AWS_DEFAULT_REGION
-    logger.info("Inference worker ready")
+def _load_and_predict(req: PredictRequest, config: ModelConfig) -> np.ndarray:
+    import torch
+    from io import BytesIO
+
+    arch_code = base64.b64decode(req.arch_bytes)
+    model_data = base64.b64decode(req.model_bytes)
+
+    with _arch_svc.load_from_bytes(req.architecture_id, arch_code) as (cls, _):
+        loaded = torch.load(BytesIO(model_data), map_location="cpu", weights_only=False)  # nosec B614
+
+        model = cls(
+            input_fields=config.input_fields,
+            output_fields=config.output_fields,
+            window_duration_seconds=config.window_duration_seconds,
+            lookback_steps=config.lookback_steps,
+            forecast_steps=config.forecast_steps,
+            hidden_size=config.hidden_size,
+        )
+        model.model = loaded
+
+        X = np.frombuffer(base64.b64decode(req.X_bytes), dtype=np.float32).reshape(req.X_shape)
+        X = np.nan_to_num(X, nan=0.0)
+        return model.predict(X)
 
 
 @app.post("/predict", response_model=PredictResponse)
@@ -57,34 +73,15 @@ async def predict(req: PredictRequest):
     except Exception as e:
         raise HTTPException(status_code=422, detail=f"Invalid config: {e}")
 
-    if req.model_uri not in _model_cache:
-        if len(_model_cache) >= _MAX_CACHE:
-            oldest = next(iter(_model_cache))
-            del _model_cache[oldest]
-        try:
-            model = await asyncio.to_thread(
-                load_trained_model, req.architecture, req.model_uri, config
-            )
-            _model_cache[req.model_uri] = model
-            logger.info("Cached model %s", req.model_uri)
-        except Exception as e:
-            logger.error("Failed to load %s: %s", req.model_uri, e)
-            raise HTTPException(status_code=500, detail=f"Model load failed: {e}")
-
-    model = _model_cache[req.model_uri]
-
     try:
-        X = np.frombuffer(base64.b64decode(req.X_bytes), dtype=np.float32).reshape(req.X_shape)
-        X = np.nan_to_num(X, nan=0.0)
-        raw = await asyncio.to_thread(model.predict, X)
+        raw = await asyncio.to_thread(_load_and_predict, req, config)
         raw = np.ascontiguousarray(raw, dtype=np.float32)
         return PredictResponse(
             output_bytes=base64.b64encode(raw.tobytes()).decode(),
             output_shape=list(raw.shape),
         )
     except Exception as e:
-        _model_cache.pop(req.model_uri, None)
-        logger.error("Prediction failed for %s: %s", req.model_uri, e)
+        logger.error("Prediction failed: %s", e)
         raise HTTPException(status_code=500, detail=f"Prediction failed: {e}")
 
 


### PR DESCRIPTION
## Summary
Change inference flow to provide full isolation of inference-worker. 

## Changes
- mlservice fetches architecture file and sends to inference
- remove credentials from inference_worker
- move inference_worker to an internal network ( can only be reached from mlservice )

## Drawbacks
- File is passed 2 times on http (minio -> mlservice -> inference_worker)