### PR TITLE
Add per loop client

### DIFF
--- a/src/services/data_storage_client.py
+++ b/src/services/data_storage_client.py
@@ -1,5 +1,6 @@
 """Client for interacting with the Data Storage API."""
 
+import asyncio
 import json
 import logging
 import os
@@ -21,17 +22,27 @@ _TOKEN_URL = f"{_KC_URL}/realms/{_KC_REALM}/protocol/openid-connect/token"
 _cached_token: str | None = None
 _token_expires_at: float = 0.0
 
-_http_client: httpx.AsyncClient | None = None
+# Per-event-loop AsyncClient cache. Sharing one httpx client across loops
+# triggers "Event loop is closed" / "bound to a different event loop" because
+# httpx internals (asyncio.Lock, transport pools) are pinned to the loop where
+# the client was instantiated. Training jobs run via asyncio.run() inside
+# thread pool workers, creating short-lived loops separate from the FastAPI
+# main loop, so a process-wide singleton breaks the moment a worker loop
+# closes and the next call lands back on a different loop.
+_http_clients: dict[int, httpx.AsyncClient] = {}
 
 
 def _get_http_client() -> httpx.AsyncClient:
-    global _http_client
-    if _http_client is None or _http_client.is_closed:
-        _http_client = httpx.AsyncClient(
+    loop = asyncio.get_event_loop()
+    key = id(loop)
+    client = _http_clients.get(key)
+    if client is None or client.is_closed:
+        client = httpx.AsyncClient(
             timeout=60.0,
             limits=httpx.Limits(max_connections=50, max_keepalive_connections=20),
         )
-    return _http_client
+        _http_clients[key] = client
+    return client
 
 
 async def _get_service_token() -> str | None:

--- a/src/services/safe_predict.py
+++ b/src/services/safe_predict.py
@@ -1,3 +1,4 @@
+import asyncio
 import base64
 import logging
 import os
@@ -10,7 +11,12 @@ from src.core.config import settings
 
 logger = logging.getLogger(__name__)
 
-_async_client: httpx.AsyncClient | None = None
+# Per-event-loop AsyncClient cache. See data_storage_client.py for full
+# rationale: a singleton httpx.AsyncClient pins asyncio primitives to the
+# loop where it was created, so reusing it from a worker thread's
+# asyncio.run() loop raises "Event loop is closed" / "bound to a different
+# event loop".
+_async_clients: dict[int, httpx.AsyncClient] = {}
 _sync_client: httpx.Client | None = None
 
 # Cache: model_uri -> (arch_bytes, model_bytes)
@@ -19,13 +25,16 @@ _MAX_BYTES_CACHE = 20
 
 
 def _get_async_client() -> httpx.AsyncClient:
-    global _async_client
-    if _async_client is None or _async_client.is_closed:
-        _async_client = httpx.AsyncClient(
+    loop = asyncio.get_event_loop()
+    key = id(loop)
+    client = _async_clients.get(key)
+    if client is None or client.is_closed:
+        client = httpx.AsyncClient(
             timeout=60.0,
             limits=httpx.Limits(max_connections=100, max_keepalive_connections=20),
         )
-    return _async_client
+        _async_clients[key] = client
+    return client
 
 
 def _get_sync_client() -> httpx.Client:


### PR DESCRIPTION
## Summary
Change singleton logic to have one instance per event_loop.

## Reasons 
- when trying multiple ml requests, the singleton is at first set to event loop `A`(the letter is just for easy understanding), but then the same instance is requested on event loop `B` causing asyncio erros ( `asyncio.locks.Event object at 0x7fda88065910 [unset]> is bound to a different event loop`, `Event loop is closed`)